### PR TITLE
Staging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         config_set:
-          - neutron_x86_ubuntu
+          - base_x86_ubuntu
           - edge_aarch64_debian
           - edge_aarch64_ubuntu
           - edge_x86_centos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,16 @@ jobs:
           - edge_aarch64_ubuntu
           - edge_x86_centos
     steps:
+      - name: Set env to staging
+        if: endsWith(github.ref, '/staging')
+        run: |
+          echo "KOLLA_NAMESPACE=kolla-dev" >> $GITHUB_ENV
+          echo "SHOULD_PUSH=1" >> $GITHUB_ENV
+      - name: Set env to production
+        if: endsWith(github.ref, '/master')
+        run: |
+          echo "KOLLA_NAMESPACE=kolla" >> $GITHUB_ENV
+          echo "SHOULD_PUSH=1" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
@@ -30,12 +40,6 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - name: Set env to staging
-        if: endsWith(github.ref, '/staging')
-        run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
-      - name: Set env to production
-        if: endsWith(github.ref, '/master')
-        run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/build.py
+++ b/build.py
@@ -81,16 +81,6 @@ def cli(config_file=None, config_set=None, build_dir=None, push=None, use_cache=
         "locals_base": "../sources",
     }
 
-    docker_tag = os.getenv("DOCKER_TAG")
-    if docker_tag:
-        kolla_config["tag"] = docker_tag
-    openstack_release = os.getenv("OPENSTACK_BASE_RELEASE")
-    if openstack_release:
-        kolla_config["openstack_release"] = openstack_release
-    profile = os.getenv("KOLLA_BUILD_PROFILE")
-    if profile:
-        kolla_config["profile"] = profile
-
     default_config_set = build_config.get("defaults", {})
     # Extract build conf extras; they are not a "real" kolla config
     # option and can't be passed to Kolla.
@@ -105,6 +95,20 @@ def cli(config_file=None, config_set=None, build_dir=None, push=None, use_cache=
         cfgset_build_conf_extras = config_set.pop("build_conf_extras", {})
         kolla_config.update(config_set)
         build_conf_extras.update(cfgset_build_conf_extras)
+
+    kolla_namespace = os.getenv("KOLLA_NAMESPACE")
+    if kolla_namespace:
+        kolla_config["namespace"] = kolla_namespace
+
+    docker_tag = os.getenv("DOCKER_TAG")
+    if docker_tag:
+        kolla_config["tag"] = docker_tag
+    openstack_release = os.getenv("OPENSTACK_BASE_RELEASE")
+    if openstack_release:
+        kolla_config["openstack_release"] = openstack_release
+    profile = os.getenv("KOLLA_BUILD_PROFILE")
+    if profile:
+        kolla_config["profile"] = profile
 
     kolla_argv = []
     for arg, value in kolla_config.items():

--- a/build_config.yaml
+++ b/build_config.yaml
@@ -112,7 +112,12 @@ config_sets:
     base_arch: x86_64
     profile: edge
 
-  neutron_x86_ubuntu:
+  base_x86_ubuntu:
     base: ubuntu
     base_tag: "18.04"
-    profile: neutron
+    base_arch: x86_64
+    platform: linux/amd64
+    profiles:
+      - base
+      - grafana
+      - neutron

--- a/kolla-build.conf.j2
+++ b/kolla-build.conf.j2
@@ -26,6 +26,8 @@ zun = ^zun-
 # For building just the edge services
 edge = ^(openstack-)?base,^cyborg-(base|agent),etcd,kuryr,^neutron-(base|openvswitch),^openvswitch,^zun-(base|compute)
 
+grafana = ^grafana
+
 [openstack-base]
 location = $tarballs_base/requirements/requirements-stable-{{ openstack_release }}.tar.gz
 


### PR DESCRIPTION
pull staging into master. This PR does 3 main things:

1. env vars are read after config sets, so have priority. This allows GH actions to push to a different namespace in the staging branch than on master. It also is in preparation for passing build profiles for manual runs, and triggered webhooks from other repos.
2. A config set can now use a list of profiles, and kolla will merge them appropriately.  This allows for simpler profile definitions, rather than maintaining multiple sets of dependencies.
3. Added grafana profile, and added to ubuntu_x86 build.


The final outcome should be a build matrix with one entry per supported OS+Architecture combination, currently:

- amd64
  - ubuntu
  - centos (not added due to conflict with jenkins)
- arm64
  - ubuntu
  - centos
  - debian