### PR TITLE
allow manual trigger of a build with profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,19 @@ name: ci
 
 on:
   push:
+    branches:
+      - master
+      - staging
+  workflow_dispatch:
+    inputs:
+      kolla_build_profile:
+        description: "Kolla Profle to build"
+        required: true
 
 env:
   DOCKER_REGISTRY: docker.chameleoncloud.org
+  KOLLA_BUILD_PROFILE: ${{ github.event.inputs.kolla_build_profile}}
+  KOLLA_NAMESPACE: kolla-dev
 
 jobs:
   buildx:
@@ -21,9 +31,7 @@ jobs:
     steps:
       - name: Set env to staging
         if: endsWith(github.ref, '/staging')
-        run: |
-          echo "KOLLA_NAMESPACE=kolla-dev" >> $GITHUB_ENV
-          echo "SHOULD_PUSH=1" >> $GITHUB_ENV
+        run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
       - name: Set env to production
         if: endsWith(github.ref, '/master')
         run: |
@@ -49,7 +57,6 @@ jobs:
           install: true
       - name: Login to Registry
         uses: docker/login-action@v1
-        if: ${{ env.SHOULD_PUSH }}
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.CC_REGISTRY_USERNAME }}


### PR DESCRIPTION
Use workflow dispatch event to trigger builds
Required input is a build profile. This will be built for all platforms.

This action is documented here: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch

Per those docs, the github_ref will be the branch that received the dispatch, and the github_sha will be the last commit on that branch. Therefore, the behavior to push containers on the master and staging branches is unchanged.

Re-created the PR, since the button only appears on the default branch...