### PR TITLE
basic support for buildx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 click
 Jinja2
 pyyaml
+python_on_whales
+graphviz
+pydot

--- a/templates/docker-bake.hcl.j2
+++ b/templates/docker-bake.hcl.j2
@@ -1,0 +1,15 @@
+# docker-bake.hcl
+variable "TAG" {
+    default = "train"
+}
+
+group "default" {
+    targets = {{ target_names | replace("'", '"') }}
+}
+
+{% for target in targets %}
+target {{target.name}} {
+    context = "{{target.context}}"
+    tags = {{ target.tags | replace("'", '"') }}
+}
+{% endfor %}


### PR DESCRIPTION
This PR replaces kolla's "build" stage with docker buildx to allow for better use of build-cache and image tagging.

It templates a docker 'bakefile', that can be build by buildx and contains all needed information (paths, tags, platforms, etc)

Current issues:
1. `openstack-base` fails to build, kolla is internally sending a tarball for context, rather than a directory path
2. container dependenceies are not handled properly by buildx. we instead need to trigger a separate buildx build for each "level" of the tree