### PR TITLE
Migrate from docker.chameleoncloud.org to ghcr.io registries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ on:
         description: "Override default tag"
 
 env:
-  DOCKER_REGISTRY: docker.chameleoncloud.org
-  KOLLA_NAMESPACE: kolla-dev
+  DOCKER_REGISTRY: ghcr.io
+  KOLLA_NAMESPACE_DEV: ChameleonCloud/kolla-dev
+  KOLLA_NAMESPACE_PROD: ChameleonCloud/kolla
 
 jobs:
   buildx:
@@ -30,11 +31,13 @@ jobs:
     steps:
       - name: Set env to staging
         if: endsWith(github.ref, '/staging')
-        run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
+        run: |
+          echo "KOLLA_NAMESPACE=$KOLLA_NAMESPACE_DEV" >> $GITHUB_ENV
+          echo "SHOULD_PUSH=1" >> $GITHUB_ENV
       - name: Set env to production
         if: endsWith(github.ref, '/master') || endsWith(github.ref, '/xena')
         run: |
-          echo "KOLLA_NAMESPACE=kolla" >> $GITHUB_ENV
+          echo "KOLLA_NAMESPACE=KOLLA_NAMESPACE_PROD" >> $GITHUB_ENV
           echo "SHOULD_PUSH=1" >> $GITHUB_ENV
 
       - name: Set profile argument from workflow inputs
@@ -74,8 +77,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.CC_REGISTRY_USERNAME }}
-          password: ${{ secrets.CC_REGISTRY_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Inspect builder
         run: |
           echo "Name:      ${{ steps.buildx.outputs.name }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ on:
 
 env:
   DOCKER_REGISTRY: ghcr.io
-  KOLLA_NAMESPACE_DEV: ChameleonCloud/kolla-dev
-  KOLLA_NAMESPACE_PROD: ChameleonCloud/kolla
+  KOLLA_NAMESPACE_DEV: chameleoncloud/kolla-dev
+  KOLLA_NAMESPACE_PROD: chameleoncloud/kolla
 
 jobs:
   buildx:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         config_set:
-          - x86_centos
           - x86_ubuntu
     steps:
       - name: Set env to staging
@@ -56,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Cache python deps
         uses: actions/cache@v3
         with:

--- a/build_config.yaml
+++ b/build_config.yaml
@@ -3,7 +3,9 @@ defaults:
   # Which registry to push built images to
   # (requires having already authenticated
   # as a user with push access)
-  registry: docker.chameleoncloud.org
+  registry: ghcr.io
+  namespace: chameleoncloud/kolla
+
   # The base release of OpenStack to build from.
   # This determines which checkout of Kolla
   # to use, as well as the base requirements that
@@ -22,7 +24,7 @@ defaults:
   # Kolla image defaults, shouldn't need to change
   # these any time soon.
   type: source
-  namespace: kolla
+
   # EXTRA PARAMETERS
   # These are just used to template the *.j2 files for the kolla
   # build configuration

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -1,5 +1,13 @@
 {% extends parent_template %}
 
+########
+# Labels
+########
+{% block labels %}
+LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build_date }}"
+LABEL org.opencontainers.image.source="https://github.com/chameleoncloud/kolla-containers"
+{% endblock %}
+
 #########
 # Blazar
 #########


### PR DESCRIPTION
Besides changing the registry mirror, the main change is to reference github.actor and GITHUB_TOKEN for authentication.

Note: to build and push locally (not with the Action!), you'll need to use a personal access token to authenticate.
For details, see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic