### PR TITLE
Remove a templating layer, update build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,23 @@
-name: multi-configset
+name: build-containers
 
 on:
   workflow_dispatch:
     inputs:
       kolla_build_profile:
         description: "Kolla profile(s) to build (e.g., 'base', 'ironic'), comma-separated"
-      build_pattern:
+      kolla_build_pattern:
         description: "Kolla image build pattern (e.g., '^ironic-')"
       push:
-        description: "Push images to registry? (yes/no)"
+        type: boolean
+        description: "Push images to registry? (true/false)"
         required: true
-        default: "no"
-        options:
-          - "yes"
-          - "no"
+        default: false
       tag:
         description: "Override default tag"
+      cache:
+        type: boolean
+      pull:
+        type: boolean
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -23,24 +25,25 @@ env:
   KOLLA_NAMESPACE_PROD: chameleoncloud/kolla
 
 jobs:
-  buildx:
+  build-containers:
     environment: Chameleon CI
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config_set:
-          - x86_ubuntu
     steps:
       - name: Set profile argument from workflow inputs
         if: github.event.inputs.kolla_build_profile != ''
         run: echo "KOLLA_BUILD_PROFILE=${{ github.event.inputs.kolla_build_profile }}" >> $GITHUB_ENV
       - name: Set pattern argument from workflow inputs
-        if: github.event.inputs.build_pattern != ''
-        run: echo "KOLLA_BUILD_PATTERN=${{ github.event.inputs.build_pattern }}" >> $GITHUB_ENV
+        if: github.event.inputs.kolla_build_pattern != ''
+        run: echo "KOLLA_BUILD_PATTERN=${{ github.event.inputs.kolla_build_pattern }}" >> $GITHUB_ENV
       - name: Set push argument from workflow inputs
-        if: github.event.inputs.push == 'yes'
+        if: github.event.inputs.push == true
         run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
+      - name: Set Cache argument from workflow inputs
+        if: github.event.inputs.cache == true
+        run: echo "KOLLA_CACHE=1" >> $GITHUB_ENV
+      - name: Set Pull argument from workflow inputs
+        if: github.event.inputs.pull == true
+        run: echo "PULL=1" >> $GITHUB_ENV
       - name: Set tag argument from workflow inputs
         if: github.event.inputs.tag != ''
         run: echo "DOCKER_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
@@ -51,13 +54,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - name: Cache python deps
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip' # caching pip dependencies
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -71,16 +68,6 @@ jobs:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Inspect builder
-        run: |
-          echo "Name:      ${{ steps.buildx.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       - name: Run Kolla Build
         run: |
-          ./run.sh python build.py --config-set ${{ matrix.config_set }} \
-            ${{ fromJSON('["--no-push", "--push"]')[env.SHOULD_PUSH] }}
-      - name: List Build Images
-        run: docker image ls
+          ./run.sh python3 do_build.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /kolla/
 # Virtualenv for tox bootstrapping
 /venv/
+.venv
 # Templated config
 kolla-build.conf
 # Python build files

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -1,6 +1,16 @@
 [DEFAULT]
 maintainer = University of Chicago
 
+registry = ghcr.io
+namespace = chameleoncloud/kolla
+openstack_release = xena
+tag = xena
+type = source
+base = ubuntu
+base_tag = "20.04"
+base_arch = x86_64
+platform = linux/amd64
+
 [profiles]
 base = ^base,chrony,cron,elasticsearch,fluentd,kibana,kolla-toolbox,haproxy,keepalived,letsencrypt,mariadb,memcached,openstack-base,^openvswitch,prometheus,grafana,rabbitmq,redis,tgtd
 blazar = ^blazar-
@@ -30,25 +40,25 @@ grafana = ^grafana
 [blazar-base]
 type = git
 location = https://github.com/ChameleonCloud/blazar.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [blazar-manager-additions-extra]
 type = local
-location = $locals_base/additions.tar
+location = blazar/additions/blazar-manager
 
 [cinder-base]
 type = url
-location = $tarballs_base/cinder/cinder-stable-{{ openstack_release }}.tar.gz
+location = $tarballs_base/cinder/cinder-stable-xena.tar.gz
 
 [cyborg-base]
 type = git
 location = https://github.com/ChameleonCloud/cyborg.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [doni-base]
 type = git
 location = https://github.com/ChameleonCloud/doni.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 # NOTE(jason): Gnocchi uses 4.3 as that's the closest to xena; consider updating
 # when we move past xena on the base.
@@ -60,85 +70,80 @@ location = https://github.com/gnocchixyz/gnocchi.git
 [heat-base]
 type = git
 location = https://github.com/ChameleonCloud/heat.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [horizon-additions-theme-chameleoncloud]
 type = git
 location = https://github.com/ChameleonCloud/horizon-theme.git
 reference = master
 
-{# Only override default horizon builds if we're building NOT for KVM;
-   The KVM build should use the default Horizon build, as we customize the
-   GUI for the bare metal use case significantly. #}
-{% if "horizon_kvm" not in profiles %}
+
 [horizon]
 type = git
 location = https://github.com/ChameleonCloud/horizon.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [horizon-plugin-blazar-dashboard]
 type = git
 location = https://github.com/ChameleonCloud/blazar-dashboard.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [horizon-plugin-heat-dashboard]
 type = git
 location = https://github.com/ChameleonCloud/heat-dashboard.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [horizon-plugin-zun-ui]
 type = git
 location = https://github.com/ChameleonCloud/zun-ui.git
-reference = stable/{{ openstack_release }}
-{% endif %}
+reference = stable/xena
+
 
 [ironic-base]
 type = git
 location = https://github.com/ChameleonCloud/ironic.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [neutron-base]
 type = git
 location = https://github.com/ChameleonCloud/neutron.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [neutron-base-plugin-networking-generic-switch]
 type = git
 location = https://github.com/ChameleonCloud/networking-generic-switch.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
-{% if enable_networking_wireguard %}
 [neutron-base-plugin-networking-wireguard]
 type = git
 location = https://github.com/ChameleonCloud/networking-wireguard.git
-reference = chameleoncloud/{{ openstack_release }}
-{% endif %}
+reference = chameleoncloud/xena
 
 [neutron-server-additions-extra]
 type = local
-location = $locals_base/additions.tar
+location = neutron/additions/neutron-server
 
 [nova-base]
 type = git
 location = https://github.com/ChameleonCloud/nova.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [nova-base-plugin-blazar]
 type = git
 location = https://github.com/ChameleonCloud/blazar-nova.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [tunelo-base]
 type = git
 location = https://github.com/ChameleonCloud/tunelo.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena
 
 [zun-base]
 type = git
 location = https://github.com/ChameleonCloud/zun.git
-reference = chameleoncloud/{{ openstack_release }}
+reference = chameleoncloud/xena

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -46,9 +46,9 @@ reference = chameleoncloud/xena
 type = local
 location = blazar/additions/blazar-manager
 
-[cinder-base]
-type = url
-location = $tarballs_base/cinder/cinder-stable-xena.tar.gz
+# [cinder-base]
+# type = url
+# location = $tarballs_base/cinder/cinder-stable-xena.tar.gz
 
 [cyborg-base]
 type = git

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -70,6 +70,11 @@ RUN pip --no-cache-dir install --upgrade \
 # Neutron
 ##########
 
+{% block neutron_base_header %}
+# version 1.0.0 doesn't work for python3, conflicts with xena upper-constraints
+RUN sed -i 's|^etcd3gw===.*$||g' requirements/upper-constraints.txt
+{% endblock %}
+
 # See "neutron-server-additions-extra" section in kolla-build.conf
 {% block neutron_server_footer %}
 ADD additions-archive /

--- a/run.sh
+++ b/run.sh
@@ -51,18 +51,22 @@ if [[ "${CHECK_UPDATES}" == "yes" || "${FORCE_UPDATES}" == "yes" ]]; then
     sha256sum "${pip_requirements}" >"${pip_requirements_chksum}"
   fi
 
-  kolla_remote=https://github.com/chameleoncloud/kolla.git
-  kolla_checkout="${KOLLA_BRANCH}"
-  kolla_gitref="${VIRTUALENV}"/kolla.gitref
-  kolla_egglink="${VIRTUALENV}"/src/kolla
-  if [[ "${FORCE_UPDATES}" == "yes" || ! -f "${kolla_gitref}" || ! -d "${kolla_egglink}" ]] || \
-        ! diff -q >/dev/null \
-          "${kolla_gitref}" \
-          <(cd "${kolla_egglink}"; git fetch; git show-ref -s -d origin/"${kolla_checkout}"); then
-    pushd "${VIRTUALENV}" || ( echo "pushd error!" && exit 1 )
-    pip install -e git+"${kolla_remote}"@"${kolla_checkout}"#egg=kolla
-    popd || ( echo "popd error!" && exit 1 )
-    (cd "${kolla_egglink}"; git rev-parse HEAD >"${kolla_gitref}")
+  if [ -z ${KOLLA_LOCAL_CHECKOUT+x} ]; then
+    kolla_remote=https://github.com/chameleoncloud/kolla.git
+    kolla_checkout="${KOLLA_BRANCH}"
+    kolla_gitref="${VIRTUALENV}"/kolla.gitref
+    kolla_egglink="${VIRTUALENV}"/src/kolla
+    if [[ "${FORCE_UPDATES}" == "yes" || ! -f "${kolla_gitref}" || ! -d "${kolla_egglink}" ]] || \
+          ! diff -q >/dev/null \
+            "${kolla_gitref}" \
+            <(cd "${kolla_egglink}"; git fetch; git show-ref -s -d origin/"${kolla_checkout}"); then
+      pushd "${VIRTUALENV}" || ( echo "pushd error!" && exit 1 )
+      pip install -e git+"${kolla_remote}"@"${kolla_checkout}"#egg=kolla
+      popd || ( echo "popd error!" && exit 1 )
+      (cd "${kolla_egglink}"; git rev-parse HEAD >"${kolla_gitref}")
+    fi
+  else
+    pip install -e ${KOLLA_LOCAL_CHECKOUT}
   fi
 fi
 

--- a/tests/test_blazar_manager.sh
+++ b/tests/test_blazar_manager.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ensure that lease end script is present
+docker run --rm -it \
+    ghcr.io/chameleoncloud/kolla/ubuntu-source-blazar-manager:xena-dc5823b \
+    stat /etc/blazar/blazar-manager/hooks/on_before_end.py
+
+docker run --rm -it \
+    ghcr.io/chameleoncloud/kolla/ubuntu-source-blazar-manager:xena-dc5823b \
+    stat /usr/local/bin/blazar_before_end_action_email

--- a/tests/test_neutron_server.sh
+++ b/tests/test_neutron_server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ensure patch 0001 is present
+docker run --rm -it \
+    ghcr.io/chameleoncloud/kolla/ubuntu-source-neutron-server:xena-dc5823b \
+    grep "startup-config\""  /var/lib/kolla/venv/lib/python3.8/site-packages/netmiko/dell/dell_force10_ssh.py
+
+docker run --rm -it \
+    ghcr.io/chameleoncloud/kolla/ubuntu-source-neutron-server:xena-dc5823b \
+    grep '"dell_fnioa": DellForce10SSH'  /var/lib/kolla/venv/lib/python3.8/site-packages/netmiko/ssh_dispatcher.py


### PR DESCRIPTION
This PR does a bunch of cleaning up in an attempt to reduce complexity and CI failures.

We now have a mostly straightforward invocation of `kolla-build`, and happen to use `build.py` just to transform environment variables into CLI arguments.

Finally, in order to resolve a couple of failures noted during build, neutron and cinder templates are slightly adjusted.