### PR TITLE
default docker tag to git ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,24 +17,9 @@ on:
           - 'false'
       tag:
         description: "Override default tag"
-      cache:
-        type: choice
-        default: 'false'
-        options:
-          - 'true'
-          - 'false'
-      pull:
-        description: "Should kolla-build pull the OS bas image before build"
-        type: choice
-        default: 'false'
-        options:
-          - 'true'
-          - 'false'
 
 env:
   DOCKER_REGISTRY: ghcr.io
-  KOLLA_NAMESPACE_DEV: chameleoncloud/kolla-dev
-  KOLLA_NAMESPACE_PROD: chameleoncloud/kolla
 
 jobs:
   build-containers:
@@ -50,12 +35,6 @@ jobs:
       - name: Set push argument from workflow inputs
         if: github.event.inputs.push == 'true'
         run: echo "SHOULD_PUSH=1" >> $GITHUB_ENV
-      - name: Set Cache argument from workflow inputs
-        if: github.event.inputs.cache == 'true'
-        run: echo "KOLLA_CACHE=1" >> $GITHUB_ENV
-      - name: Set Pull argument from workflow inputs
-        if: github.event.inputs.pull == 'true'
-        run: echo "PULL=1" >> $GITHUB_ENV
       - name: Set tag argument from workflow inputs
         if: github.event.inputs.tag != ''
         run: echo "DOCKER_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -4,7 +4,10 @@ maintainer = University of Chicago
 registry = ghcr.io
 namespace = chameleoncloud/kolla
 openstack_release = xena
-tag = xena
+
+# tag is set in run.sh, not here
+# tag = xena
+
 type = source
 base = ubuntu
 base_tag = "20.04"

--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,18 @@ fi
 
 # Set these _after_ sourcing a possible .env file, so it can be defaulted there.
 KOLLA_BRANCH="${KOLLA_BRANCH:-chameleoncloud/xena}"
-DOCKER_TAG="${DOCKER_TAG:-xena}"
+
+# by default, tag containers with the git sha for kolla-containers repo
+GIT_REF="$(git rev-parse --abbrev-ref HEAD)"
+
+# replace '/' with '-' since container tags cannot contain '/'
+GIT_REF_DASH=${GIT_REF//'/'/"-"}
+if [[ -n $(git status --porcelain) ]]; then
+  GIT_REF_DASH="${GIT_REF_DASH}-dirty"
+fi
+
+# if DOCKER_TAG env var is set, use that, otherwise use git ref as tag
+export DOCKER_TAG="${DOCKER_TAG:-$GIT_REF_DASH}"
 
 # Automatically update dependencies
 if [[ "${CHECK_UPDATES}" == "yes" || "${FORCE_UPDATES}" == "yes" ]]; then


### PR DESCRIPTION
if DOCKER_TAG is not set, set a tag corresponding to the git ref e.g. if the branch is `wip/foo_bar`, the tag will be `wip-foo_bar`

if the DOCKER_TAG is set, it will still take precedence.

This new behavior ensures that builds from different branches will not collide, and is a prerequisite for enabling automatic builds.