### PR TITLE
add support for arm64 ipxe in ironic container

### DIFF
--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -36,6 +36,19 @@ RUN pip --no-cache-dir install \
   git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1#egg=python-blazarclient
 {% endblock %}
 
+#########
+# Ironic
+#########
+
+# We need an arm64 ipxe binary to support fugaku nodes at tacc, and arm thunder x2 at ncar.
+# we build them ourselves to ensure that support for gzip compressed images is enabled.
+
+{% set ironic_pxe_packages_append = ['unzip'] %}
+{% block ironic_pxe_footer %}
+ADD https://github.com/ChameleonCloud/ipxe/releases/download/v2022-09-30-chameleon/bin-arm64-efi.zip /opt/ipxe_efi.zip
+RUN (mkdir -p /usr/lib/ipxe/aarch64 && cd /usr/lib/ipxe/aarch64 && unzip /opt/ipxe_efi.zip)
+{% endblock %}
+
 
 ##########
 # Keystone


### PR DESCRIPTION
This change ALSO needs a change to our kolla-fork, since we need to modify kolla-extend start.
https://github.com/ChameleonCloud/kolla/commit/507ac6e2e5a22010d385dd9455d9e1b45baaade5

Splitting it across repos like this is ugly, and goes against our goal of keeping our fork of `kolla` as close to upstream as possible.
Another avenue would be to do it entirely inside our fork of kolla-ansible, and load it it at deploy-time, but this gets it done.

We should revert this, (and the kolla change) if upstream gets support for both variants.