### PR TITLE
container builds for flavor reservation

### DIFF
--- a/blazar/additions/blazar-manager/hooks/on_before_end.py
+++ b/blazar/additions/blazar-manager/hooks/on_before_end.py
@@ -8,10 +8,16 @@ import argparse
 import configparser
 import sys
 import smtplib
+from blazarclient.client import Client as BlazarClient
 from datetime import datetime
 from dateutil import tz
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from keystoneauth1 import session
+from keystoneauth1.identity import v3
+
+import openstack
+
 
 from jinja2 import Environment
 
@@ -43,13 +49,28 @@ a:hover { color: #B40057; background-color:#C4FFF9; text-decoration: underline }
 <p>We're sending this email to inform you that your lease {{ vars['leasename'] }} (ID: {{ vars['leaseid'] }}) under project {{ vars['projectname'] }} on {{ vars['site'] }}
 will expire on {{ vars['enddatetime_utc'] }} UTC / {{ vars['enddatetime_ct'] }} Central Time.</p>
 
+{% if vars['servers']  %}
+<p>The following instances are provisioned on nodes in this lease, and will be deleted if when the lease ends:</p>
+<ul>
+  {% for server in vars['servers'] %}
+    <li>{{ server.name }} ({{ server.id }})</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
 <p>You can extend your lease using
 either the Chameleon <a href='https://chameleoncloud.readthedocs.io/en/latest/technical/reservations.html#extending-a-lease' target='_blank'>web interface</a>
 or <a href='https://chameleoncloud.readthedocs.io/en/latest/technical/reservations.html#id5' target='_blank'>command line interface</a>.</p>
 
+{% if vars['site'] == 'KVM@TACC' %}
+<p>If you cannot or do not wish to extend your lease, you can save the configuration of instances and relaunch them with
+<a href="https://chameleoncloud.readthedocs.io/en/latest/technical/kvm/kvm_gui.html#creating-a-instance-snapshot" target="_blank">image snapshots</a>.
+</p>
+{% else %}
 <p>If you cannot or do not wish to extend your lease, you can save the configuration of instances and relaunch them with updated
 images at a later time by using the <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/images.html" target="_blank">cc-snapshot utility</a>
 , which is presinstalled on all Chameleon supported images.</p>
+{% endif %}
 
 <br>
 <p><i>
@@ -131,6 +152,7 @@ def main(argv):
 
     parser.add_argument("--username", type=str, help="User name", required=True)
     parser.add_argument("--project-name", type=str, help="Project name", required=True)
+    parser.add_argument("--project-id", type=str, help="Project ID", required=True)
     parser.add_argument("--lease-name", type=str, help="Lease name", required=True)
     parser.add_argument("--lease-id", type=str, help="Lease id", required=True)
     parser.add_argument(
@@ -144,14 +166,67 @@ def main(argv):
     ).replace(tzinfo=tz.tzutc())
     enddatetime_in_central = enddatetime_in_utc.astimezone(tz.gettz("America/Chicago"))
 
+    blazar_config = configparser.ConfigParser()
+    blazar_config.read("/etc/blazar/blazar.conf")
+    servers_in_lease = []
+    try:
+        auth_config = blazar_config['keystone_authtoken']
+        auth = v3.Password(
+            auth_url=auth_config.get('auth_url'),
+            username=auth_config.get('username'),
+            password=auth_config.get('password'),
+            user_domain_name=auth_config.get('user_domain_name', 'Default'),
+            project_name=auth_config.get('project_name'),
+            project_domain_name=auth_config.get('project_domain_name', 'Default')
+        )
+        sess = session.Session(auth=auth)
+
+        bc = BlazarClient("1", service_type="reservation", session=(sess))
+
+        conn = openstack.connection.Connection(session=sess)
+        if args.site != 'KVM@TACC':
+            hosts_by_id = {}
+            for host in bc.host.list():
+                hosts_by_id[host["id"]] = host["hypervisor_hostname"]
+            hosts_in_lease = set()
+            for resource in bc.host.list_allocations():
+                for reservation in resource["reservations"]:
+                    if args.lease_id == reservation["lease_id"]:
+                        hosts_in_lease.add(
+                            hosts_by_id[resource["resource_id"]]
+                        )
+
+            for server in conn.compute.servers(project_id=args.project_id, all_tenants=True):
+                if server.hypervisor_hostname in hosts_in_lease:
+                    servers_in_lease.append(server)
+        else:
+            # For KVM, find servers based on flavor
+            lease = bc.lease.get(args.lease_id)
+            for reservation in lease["reservations"]:
+                if reservation["resource_type"] == "flavor:instance":
+                    for server in conn.compute.servers(
+                        project_id=args.project_id,
+                        all_tenants=True
+                    ):
+                        server_res_id = server.flavor.extra_specs.get("aggregate_instance_extra_specs:reservation")
+                        if server_res_id == reservation["id"]:
+                            servers_in_lease.append(server)
+    except Exception as e:
+        # Ignore errors
+        print("Error getting server info")
+        print(e)
+        pass
+
     template_vars = {
         "username": args.username,
         "projectname": args.project_name,
+        "projectid": args.project_id,
         "leasename": args.lease_name,
         "leaseid": args.lease_id,
         "enddatetime_utc": enddatetime_in_utc.strftime("%Y-%m-%d %H:%M:%S"),
         "enddatetime_ct": enddatetime_in_central.strftime("%Y-%m-%d %H:%M:%S"),
         "site": args.site,
+        "servers": servers_in_lease,
     }
 
     td = enddatetime_in_utc - datetime.now(tz.tzutc())
@@ -168,9 +243,7 @@ def main(argv):
     email_ssl = False
     email_user = None
     email_password = None
-    blazar_config = configparser.ConfigParser()
     try:
-        blazar_config.read("/etc/blazar/blazar.conf")
         email_host = blazar_config["physical:host"]["email_relay"]
         # smtplib's default is 0, defaults to OS implementation
         email_port = blazar_config["physical:host"].get("email_port", 0)

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,7 +3,7 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = zed
+openstack_release = 2023.1
 
 base = ubuntu
 base_tag = "22.04"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/zed
+reference = backport/2023.1

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,7 +3,7 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = victoria
+openstack_release = wallaby
 
 base = ubuntu
 base_tag = "20.04"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/victoria
+reference = backport/wallaby

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,10 +3,10 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = yoga
+openstack_release = zed
 
 base = ubuntu
-base_tag = "20.04"
+base_tag = "22.04"
 base_arch = x86_64
 platform = linux/amd64
 install_type = "source"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/yoga
+reference = backport/zed

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -9,7 +9,6 @@ base = ubuntu
 base_tag = "22.04"
 base_arch = x86_64
 platform = linux/amd64
-install_type = "source"
 
 [profiles]
 #profiles here correspond roughly to the tags used by kolla-ansible during deploy
@@ -25,6 +24,35 @@ manila = ^manila-
 nova    = ^nova
 placement = ^placement
 prometheus = ^prometheus
+
+[blazar-base]
+type = git
+location = https://github.com/ChameleonCloud/blazar.git
+reference = chameleoncloud/2023.1-kvm
+
+[blazar-manager-additions-extra]
+type = local
+location = blazar/additions/blazar-manager
+
+[heat-base]
+type = git
+location = https://github.com/ChameleonCloud/heat.git
+reference = chameleoncloud/2023.1
+
+[horizon]
+type = git
+location = https://github.com/ChameleonCloud/horizon.git
+reference = chameleoncloud/2023.1-kvm
+
+[horizon-plugin-blazar-dashboard]
+type = git
+location = https://github.com/ChameleonCloud/blazar-dashboard.git
+reference = chameleoncloud/2023.1-kvm
+
+[horizon-plugin-heat-dashboard]
+type = git
+location = https://github.com/ChameleonCloud/heat-dashboard.git
+reference = chameleoncloud/2023.1
 
 [keystone-base]
 type = git

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,14 +3,12 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = 2023.1
+openstack_release = ussuri
 
 base = ubuntu
-base_tag = "22.04"
+base_tag = "18.04"
 base_arch = x86_64
 platform = linux/amd64
-
-tag = 2023.1-ubuntu-jammy
 
 [profiles]
 #profiles here correspond roughly to the tags used by kolla-ansible during deploy
@@ -27,58 +25,7 @@ nova    = ^nova
 placement = ^placement
 prometheus = ^prometheus
 
-[blazar-base]
-type = git
-location = https://github.com/ChameleonCloud/blazar.git
-reference = chameleoncloud/2023.1
-
-[blazar-manager-additions-extra]
-type = local
-location = blazar/additions/blazar-manager
-
-
-[doni-base]
-type = git
-location = https://github.com/ChameleonCloud/doni.git
-reference = chameleoncloud/2023.1
-
-[heat-base]
-type = git
-location = https://github.com/ChameleonCloud/heat.git
-reference = chameleoncloud/2023.1
-
-[horizon]
-type = git
-location = https://github.com/ChameleonCloud/horizon.git
-reference = chameleoncloud/2023.1
-
-[horizon-plugin-blazar-dashboard]
-type = git
-location = https://github.com/ChameleonCloud/blazar-dashboard.git
-reference = chameleoncloud/2023.1
-
-[horizon-plugin-heat-dashboard]
-type = git
-location = https://github.com/ChameleonCloud/heat-dashboard.git
-reference = chameleoncloud/2023.1
-
-[ironic-base]
-type = git
-location = https://github.com/ChameleonCloud/ironic.git
-reference = chameleoncloud/2023.1
-
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = chameleoncloud/2023.1
-
-
-[neutron-base-plugin-networking-generic-switch]
-type = git
-location = https://github.com/ChameleonCloud/networking-generic-switch.git
-reference = chameleoncloud/2023.1
-
-[nova-base]
-type = git
-location = https://github.com/ChameleonCloud/nova.git
-reference = chameleoncloud/2023.1
+reference = backport/ussuri

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,7 +3,7 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = wallaby
+openstack_release = xena
 
 base = ubuntu
 base_tag = "20.04"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/wallaby
+reference = backport/xena

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -9,6 +9,7 @@ base = ubuntu
 base_tag = "18.04"
 base_arch = x86_64
 platform = linux/amd64
+install_type = "source"
 
 [profiles]
 #profiles here correspond roughly to the tags used by kolla-ansible during deploy

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,10 +3,10 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = ussuri
+openstack_release = victoria
 
 base = ubuntu
-base_tag = "18.04"
+base_tag = "20.04"
 base_arch = x86_64
 platform = linux/amd64
 install_type = "source"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/ussuri
+reference = backport/victoria

--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -3,7 +3,7 @@ maintainer = University of Chicago
 
 registry = ghcr.io
 namespace = chameleoncloud/kolla
-openstack_release = xena
+openstack_release = yoga
 
 base = ubuntu
 base_tag = "20.04"
@@ -29,4 +29,4 @@ prometheus = ^prometheus
 [keystone-base]
 type = git
 location = https://github.com/ChameleonCloud/keystone.git
-reference = backport/xena
+reference = backport/yoga

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -14,3 +14,14 @@ LABEL org.opencontainers.image.source="https://github.com/chameleoncloud/kolla-c
 {% block fluentd_footer %}
 RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 {% endblock %}
+
+#########
+# Blazar
+#########
+
+{% block blazar_manager_footer %}
+ADD additions-archive /
+RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
+  && chown -R blazar: /etc/blazar \
+  && ln -s /etc/blazar/hooks/on_before_end.py /usr/local/bin/blazar_before_end_action_email
+{% endblock %}

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -19,15 +19,14 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 # Horizon
 #########
 
-{% block horizon_footer %}
 # [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
-RUN pip --no-cache-dir install \
-  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
-{% endblock %}
+{% set horizon_pip_packages_append = ['chameleon-blazarclient'] %}
 
 #########
 # Blazar
 #########
+
+{% set blazar_base_pip_packages_append = ['chameleon-blazarclient'] %}
 
 {% block blazar_manager_footer %}
 ADD additions-archive /

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -8,83 +8,9 @@ LABEL maintainer="{{ maintainer }}" name="{{ image_name }}" build-date="{{ build
 LABEL org.opencontainers.image.source="https://github.com/chameleoncloud/kolla-containers"
 {% endblock %}
 
-################
-# Openstack-Base
-################
-
-{% block openstack_base_footer %}
-RUN {{ macros.upper_constraints_remove("netmiko") }}
-{% endblock %}
-
 #########
 # Fluentd
 #########
 {% block fluentd_footer %}
 RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 {% endblock %}
-
-#########
-# Blazar
-#########
-
-{% block blazar_manager_footer %}
-ADD additions-archive /
-RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
-  && chown -R blazar: /etc/blazar \
-  && ln -s /etc/blazar/hooks/on_before_end.py /usr/local/bin/blazar_before_end_action_email
-{% endblock %}
-
-#########
-# Horizon
-#########
-
-{% block horizon_footer %}
-# [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
-RUN pip --no-cache-dir install \
-  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1#egg=python-blazarclient
-{% endblock %}
-
-#########
-# Ironic
-#########
-
-# We need an arm64 ipxe binary to support fugaku nodes at tacc, and arm thunder x2 at ncar.
-# we build them ourselves to ensure that support for gzip compressed images is enabled.
-
-{% set ironic_pxe_packages_append = ['unzip'] %}
-{% block ironic_pxe_footer %}
-ADD https://github.com/ChameleonCloud/ipxe/releases/download/v2022-09-30-chameleon/bin-arm64-efi.zip /opt/ipxe_efi.zip
-RUN (mkdir -p /usr/lib/ipxe/aarch64 && cd /usr/lib/ipxe/aarch64 && unzip /opt/ipxe_efi.zip)
-{% endblock %}
-
-
-##########
-# Keystone
-##########
-
-{% set keystone_base_packages_remove = ['libapache2-mod-auth-openidc'] %}
-{% set keystone_base_packages_append = [
-  'https://github.com/OpenIDC/mod_auth_openidc/releases/download/v2.4.15.7/libapache2-mod-auth-openidc_2.4.15.7-1.jammy_amd64.deb',
-  'libcjose0',
-  'libhiredis0.14'
-  ] %}
-
-##########
-# Neutron
-##########
-
-
-{% set neutron_base_pip_packages_append = ['git+https://github.com/ChameleonCloud/netmiko.git@chameleoncloud/v4.1.2'] %}
-{% set neutron_server_pip_packages_append = ['git+https://github.com/ChameleonCloud/netmiko.git@chameleoncloud/v4.1.2'] %}
-
-# we do this twice because kolla is installing neutron plugins twice, 
-# and upper-constraints undoes our install
-#{% block neutron_base_footer %}
-#RUN SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip --no-cache-dir install --upgrade \
-#  'git+https://github.com/ChameleonCloud/netmiko.git@chameleoncloud/v4.1.2'
-#{% endblock %}
-#
-#{% block neutron_server_footer %}
-#RUN SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip --no-cache-dir install --upgrade \
-#  'git+https://github.com/ChameleonCloud/netmiko.git@chameleoncloud/v4.1.2'
-#{% endblock %}

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -16,6 +16,16 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 {% endblock %}
 
 #########
+# Horizon
+#########
+
+{% block horizon_footer %}
+# [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
+RUN pip --no-cache-dir install \
+  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
+{% endblock %}
+
+#########
 # Blazar
 #########
 


### PR DESCRIPTION
this PR builds containers for the 2023.1 flavor reservation on kvm case.

it cannot be merged as-is, because we still need to build two separate "sets" of horizon containers for baremetal + kvm

This builds the changes pulled in from:
- https://github.com/ChameleonCloud/blazar/pull/123
- https://github.com/ChameleonCloud/blazar-dashboard/pull/44
- https://github.com/ChameleonCloud/horizon/pull/28

@Mark-Powers are we able to merge the blazar and blazar-dashboard ones? I wasn't sure if they had conflicts too.