### PR TITLE
Remove blazarclient #egg requirement

### DIFF
--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -41,7 +41,7 @@ RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
 {% block horizon_footer %}
 # [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
 RUN pip --no-cache-dir install \
-  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1#egg=python-blazarclient
+  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
 {% endblock %}
 
 #########


### PR DESCRIPTION
This is breaking CI, and is discouraged by the pip documentation:
- https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments