### PR TITLE
Add support for flavor leases

### DIFF
--- a/blazar/additions/blazar-manager/hooks/on_before_end.py
+++ b/blazar/additions/blazar-manager/hooks/on_before_end.py
@@ -170,19 +170,21 @@ def main(argv):
     blazar_config.read("/etc/blazar/blazar.conf")
     servers_in_lease = []
     try:
-        if args.site != 'KVM@TACC':
-            auth_config = blazar_config['keystone_authtoken']
-            auth = v3.Password(
-                auth_url=auth_config.get('auth_url'),
-                username=auth_config.get('username'),
-                password=auth_config.get('password'),
-                user_domain_name=auth_config.get('user_domain_name', 'Default'),
-                project_name=auth_config.get('project_name'),
-                project_domain_name=auth_config.get('project_domain_name', 'Default')
-            )
-            sess = session.Session(auth=auth)
+        auth_config = blazar_config['keystone_authtoken']
+        auth = v3.Password(
+            auth_url=auth_config.get('auth_url'),
+            username=auth_config.get('username'),
+            password=auth_config.get('password'),
+            user_domain_name=auth_config.get('user_domain_name', 'Default'),
+            project_name=auth_config.get('project_name'),
+            project_domain_name=auth_config.get('project_domain_name', 'Default')
+        )
+        sess = session.Session(auth=auth)
 
-            bc = BlazarClient("1", service_type="reservation", session=(sess))
+        bc = BlazarClient("1", service_type="reservation", session=(sess))
+
+        conn = openstack.connection.Connection(session=sess)
+        if args.site != 'KVM@TACC':
             hosts_by_id = {}
             for host in bc.host.list():
                 hosts_by_id[host["id"]] = host["hypervisor_hostname"]
@@ -194,10 +196,20 @@ def main(argv):
                             hosts_by_id[resource["resource_id"]]
                         )
 
-            conn = openstack.connection.Connection(session=sess)
             for server in conn.compute.servers(project_id=args.project_id, all_tenants=True):
                 if server.hypervisor_hostname in hosts_in_lease:
                     servers_in_lease.append(server)
+        else:
+            # For KVM, find servers based on flavor
+            lease = bc.lease.get(args.lease_id)
+            for reservation in lease["reservations"]:
+                if reservation["resource_type"] == "flavor:instance":
+                    for server in conn.compute.servers(
+                        project_id=args.project_id,
+                        flavor_id=reservation["id"],
+                        all_tenants=True
+                    ):
+                        servers_in_lease.append(server)
     except Exception as e:
         # Ignore errors
         print("Error getting server info")

--- a/blazar/additions/blazar-manager/hooks/on_before_end.py
+++ b/blazar/additions/blazar-manager/hooks/on_before_end.py
@@ -8,10 +8,16 @@ import argparse
 import configparser
 import sys
 import smtplib
+from blazarclient.client import Client as BlazarClient
 from datetime import datetime
 from dateutil import tz
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from keystoneauth1 import session
+from keystoneauth1.identity import v3
+
+import openstack
+
 
 from jinja2 import Environment
 
@@ -43,13 +49,28 @@ a:hover { color: #B40057; background-color:#C4FFF9; text-decoration: underline }
 <p>We're sending this email to inform you that your lease {{ vars['leasename'] }} (ID: {{ vars['leaseid'] }}) under project {{ vars['projectname'] }} on {{ vars['site'] }}
 will expire on {{ vars['enddatetime_utc'] }} UTC / {{ vars['enddatetime_ct'] }} Central Time.</p>
 
+{% if vars['servers']  %}
+<p>The following instances are provisioned on nodes in this lease, and will be deleted if when the lease ends:</p>
+<ul>
+  {% for server in vars['servers'] %}
+    <li>{{ server.name }} ({{ server.id }})</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
 <p>You can extend your lease using
 either the Chameleon <a href='https://chameleoncloud.readthedocs.io/en/latest/technical/reservations.html#extending-a-lease' target='_blank'>web interface</a>
 or <a href='https://chameleoncloud.readthedocs.io/en/latest/technical/reservations.html#id5' target='_blank'>command line interface</a>.</p>
 
+{% if vars['site'] == 'KVM@TACC' %}
+<p>If you cannot or do not wish to extend your lease, you can save the configuration of instances and relaunch them with
+<a href="https://chameleoncloud.readthedocs.io/en/latest/technical/kvm/kvm_gui.html#creating-a-instance-snapshot" target="_blank">image snapshots</a>.
+</p>
+{% else %}
 <p>If you cannot or do not wish to extend your lease, you can save the configuration of instances and relaunch them with updated
 images at a later time by using the <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/images.html" target="_blank">cc-snapshot utility</a>
 , which is presinstalled on all Chameleon supported images.</p>
+{% endif %}
 
 <br>
 <p><i>
@@ -131,6 +152,7 @@ def main(argv):
 
     parser.add_argument("--username", type=str, help="User name", required=True)
     parser.add_argument("--project-name", type=str, help="Project name", required=True)
+    parser.add_argument("--project-id", type=str, help="Project ID", required=True)
     parser.add_argument("--lease-name", type=str, help="Lease name", required=True)
     parser.add_argument("--lease-id", type=str, help="Lease id", required=True)
     parser.add_argument(
@@ -144,14 +166,54 @@ def main(argv):
     ).replace(tzinfo=tz.tzutc())
     enddatetime_in_central = enddatetime_in_utc.astimezone(tz.gettz("America/Chicago"))
 
+    blazar_config = configparser.ConfigParser()
+    blazar_config.read("/etc/blazar/blazar.conf")
+    servers_in_lease = []
+    try:
+        if args.site != 'KVM@TACC':
+            auth_config = blazar_config['keystone_authtoken']
+            auth = v3.Password(
+                auth_url=auth_config.get('auth_url'),
+                username=auth_config.get('username'),
+                password=auth_config.get('password'),
+                user_domain_name=auth_config.get('user_domain_name', 'Default'),
+                project_name=auth_config.get('project_name'),
+                project_domain_name=auth_config.get('project_domain_name', 'Default')
+            )
+            sess = session.Session(auth=auth)
+
+            bc = BlazarClient("1", service_type="reservation", session=(sess))
+            hosts_by_id = {}
+            for host in bc.host.list():
+                hosts_by_id[host["id"]] = host["hypervisor_hostname"]
+            hosts_in_lease = set()
+            for resource in bc.host.list_allocations():
+                for reservation in resource["reservations"]:
+                    if args.lease_id == reservation["lease_id"]:
+                        hosts_in_lease.add(
+                            hosts_by_id[resource["resource_id"]]
+                        )
+
+            conn = openstack.connection.Connection(session=sess)
+            for server in conn.compute.servers(project_id=args.project_id, all_tenants=True):
+                if server.hypervisor_hostname in hosts_in_lease:
+                    servers_in_lease.append(server)
+    except Exception as e:
+        # Ignore errors
+        print("Error getting server info")
+        print(e)
+        pass
+
     template_vars = {
         "username": args.username,
         "projectname": args.project_name,
+        "projectid": args.project_id,
         "leasename": args.lease_name,
         "leaseid": args.lease_id,
         "enddatetime_utc": enddatetime_in_utc.strftime("%Y-%m-%d %H:%M:%S"),
         "enddatetime_ct": enddatetime_in_central.strftime("%Y-%m-%d %H:%M:%S"),
         "site": args.site,
+        "servers": servers_in_lease,
     }
 
     td = enddatetime_in_utc - datetime.now(tz.tzutc())
@@ -168,9 +230,7 @@ def main(argv):
     email_ssl = False
     email_user = None
     email_password = None
-    blazar_config = configparser.ConfigParser()
     try:
-        blazar_config.read("/etc/blazar/blazar.conf")
         email_host = blazar_config["physical:host"]["email_relay"]
         # smtplib's default is 0, defaults to OS implementation
         email_port = blazar_config["physical:host"].get("email_port", 0)

--- a/blazar/additions/blazar-manager/hooks/on_before_end.py
+++ b/blazar/additions/blazar-manager/hooks/on_before_end.py
@@ -206,10 +206,11 @@ def main(argv):
                 if reservation["resource_type"] == "flavor:instance":
                     for server in conn.compute.servers(
                         project_id=args.project_id,
-                        flavor_id=reservation["id"],
                         all_tenants=True
                     ):
-                        servers_in_lease.append(server)
+                        server_res_id = server.flavor.extra_specs.get("aggregate_instance_extra_specs:reservation")
+                        if server_res_id == reservation["id"]:
+                            servers_in_lease.append(server)
     except Exception as e:
         # Ignore errors
         print("Error getting server info")

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -16,32 +16,17 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 {% endblock %}
 
 #########
-# Blazar
-#########
-
-{% block blazar_manager_footer %}
-ADD additions-archive /
-# Install our fork of blazarclient to use in email hook
-RUN pip --no-cache-dir install \
-  chameleon-blazarclient
-RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
-  && chown -R blazar: /etc/blazar \
-  && ln -s /etc/blazar/hooks/on_before_end.py /usr/local/bin/blazar_before_end_action_email
-{% endblock %}
-
-#########
 # Horizon
 #########
 
-{% block horizon_footer %}
 # [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
-RUN pip --no-cache-dir install \
-  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
-{% endblock %}
+{% set horizon_pip_packages_append = ['chameleon-blazarclient'] %}
 
 #########
 # Blazar
 #########
+
+{% set blazar_base_pip_packages_append = ['chameleon-blazarclient'] %}
 
 {% block blazar_manager_footer %}
 ADD additions-archive /

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -29,6 +29,9 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-grafana-loki
 
 {% block blazar_manager_footer %}
 ADD additions-archive /
+# Install our fork of blazarclient to use in email hook
+RUN pip --no-cache-dir install \
+  chameleon-blazarclient
 RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
   && chown -R blazar: /etc/blazar \
   && ln -s /etc/blazar/hooks/on_before_end.py /usr/local/bin/blazar_before_end_action_email

--- a/kolla-template-overrides.j2
+++ b/kolla-template-overrides.j2
@@ -41,7 +41,7 @@ RUN cp -R /additions/blazar-manager/* /etc/blazar/ \
 {% block horizon_footer %}
 # [blazar-dashboard] Override with our fork of blazarclient, which includes support for device resources
 RUN pip --no-cache-dir install \
-  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1#egg=python-blazarclient
+  git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
 {% endblock %}
 
 #########


### PR DESCRIPTION
We added support in the [KVM branch of blazar](https://github.com/ChameleonCloud/blazar/commit/8ea01c432c4de04768018418a7f562f5eebb0e9e) to support showing servers in lease reminder emails.
e.g.
```
The following instances will be deleted when this lease expires
- test1
- test2 
```

However the mapping of lease -> server didn't work, since it was only implemented for the baremetal case. The [latest 2 commits in this PR](https://github.com/ChameleonCloud/kolla-containers/pull/52/files/72a64fee30f8e5e6ecf49b146b1ebbf4321e8f15..f5a9a4de327dd75cd90d4bf9badf5c77aeaedd29) fix this by looking at the `aggregate_instance_extra_specs:reservation ` [key that blazar sets](https://github.com/ChameleonCloud/blazar/blob/chameleoncloud/2023.1-kvm/blazar/plugins/flavor/flavor_plugin.py#L464).

This PR also has a minor refactoring of the openstack connection/blazarclient object.